### PR TITLE
Delete old .config-lock before launching new daemon. Otherwise, resta…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ VOLUME ["/output"]
 
 WORKDIR /flexget
 
-CMD flexget daemon start
+CMD rm -f /flexget/.config-lock && flexget daemon start


### PR DESCRIPTION
…rts of the container would occasionally think another instance was already running and would not do anything useful.

I don't know if this is the best way to handle the problem, but I took a shot. If you are experiencing similar issues, give this change a look.
